### PR TITLE
Handle error correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,7 +320,10 @@ function buildTemplate(filename, options, callback) {
 
   // function to call when retrieved template content
   function done(err, templateText) {
-    callback(err, builtTemplateFromString(templateText, filename, options));
+    if (err) {
+      return callback(err);
+    }
+    callback(null, builtTemplateFromString(templateText, filename, options));
   }
 
   getTemplateContentFn(filename, options, done);


### PR DESCRIPTION
When template cannot be rendered, the error is not handled correctly and cause an unhandled exception.

The solution is to avoid execute the function "builtTemplateFromString" if an error ocurred.