### PR TITLE
Update packages, Support inline `def` and `use` params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 .idea/
+
+
+yarn.lock
+
+.directory

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-var _ = require("lodash");
-var fs = require("fs");
-var dot = require("dot");
-var path = require("path");
-var yaml = require("js-yaml");
+var _ = require('lodash');
+var fs = require('fs');
+var dot = require('dot');
+var path = require('path');
+var yaml = require('js-yaml');
 
 /**
- * Engine settings
- */
+* Engine settings
+*/
 var settings = {
   config: /^---([\s\S]+?)---/g,
   comment: /<!--([\s\S]+?)-->/g,
-  header: "",
+  header: '',
 
   stripComment: false,
   stripWhitespace: false, // shortcut to dot.strip
@@ -34,8 +34,8 @@ var settings = {
 };
 
 /**
- * Cache store
- */
+* Cache store
+*/
 var cache = {
   cache: {},
 
@@ -51,8 +51,8 @@ var cache = {
 };
 
 /**
- * Server-side helper
- */
+* Server-side helper
+*/
 function DotDef(options) {
   this.options = options;
   this.dirname = options.dirname;
@@ -60,11 +60,12 @@ function DotDef(options) {
 }
 
 DotDef.prototype = {
+
   partial: function(partialPath) {
-    console.log(
-      "DEPRECATED: " +
-        "Please use the new syntax for partials" +
-        " [[= partial('path/to/partial') ]]"
+
+    console.log('DEPRECATED: ' +
+    'Please use the new syntax for partials' +
+    ' [[= partial(\'path/to/partial\') ]]'
     );
 
     var template = getTemplate(
@@ -72,34 +73,35 @@ DotDef.prototype = {
       this.model
     );
 
-    return template.render({ model: this.model, isPartial: true });
+    return template.render({ model: this.model, isPartial: true, } );
   }
+
 };
 
 /**
- * @constructor Template object with a layout structure. This object is cached
- * if the 'options.cache' set by express is true.
- * @param {Object} options The constructor parameters:
- *
- * {Object} engine The option from the engine
- *
- * There are 2 options
- *
- * Case 1: A layout view
- * {String} master The master template filename
- * {Object} sections A key/value containing the sections of the template
- *
- * Case 2: A standalone view
- * {String} body The template string
- */
+* @constructor Template object with a layout structure. This object is cached
+* if the 'options.cache' set by express is true.
+* @param {Object} options The constructor parameters:
+*
+* {Object} engine The option from the engine
+*
+* There are 2 options
+*
+* Case 1: A layout view
+* {String} master The master template filename
+* {Object} sections A key/value containing the sections of the template
+*
+* Case 2: A standalone view
+* {String} body The template string
+*/
 function Template(options) {
   this.options = options;
 
   // layout
   this.isLayout = !!options.config.layout;
-  this.master = this.isLayout
-    ? path.join(options.dirname, options.config.layout)
-    : null;
+  this.master = this.isLayout ?
+    path.join(options.dirname, options.config.layout) :
+    null;
 
   // build the doT templates
   this.templates = {};
@@ -108,15 +110,14 @@ function Template(options) {
 
   // view data
   this.viewData = [];
-  if (
-    _.has(options.express, "settings") &&
-    _.has(options.express.settings, "view data")
+  if (_.has(options.express, 'settings')
+    && _.has(options.express.settings, 'view data')
   ) {
     this.settings.varname = _.reduce(
-      options.express.settings["view data"],
+      options.express.settings['view data'],
       function(result, value, key) {
         this.viewData.push(value);
-        return result + ", " + key;
+        return result + ', ' + key;
       },
       settings.dot.varname,
       this
@@ -125,12 +126,11 @@ function Template(options) {
 
   // view shortcut
   this.shortcuts = [];
-  if (
-    _.has(options.express, "settings") &&
-    _.has(options.express.settings, "view shortcut")
+  if (_.has(options.express, 'settings')
+    && _.has(options.express.settings, 'view shortcut')
   ) {
-    this.shortcuts = options.express.settings["view shortcut"];
-    this.settings.varname += ", " + _.keys(this.shortcuts).join();
+    this.shortcuts = options.express.settings['view shortcut'];
+    this.settings.varname += ', ' + _.keys(this.shortcuts).join();
   }
 
   // doT template
@@ -146,39 +146,39 @@ function Template(options) {
 }
 
 /**
- * Partial method helper
- * @param {Object} layout The layout to pass to the view
- * @param {Object} model The model to pass to the view
- */
+* Partial method helper
+* @param {Object} layout The layout to pass to the view
+* @param {Object} model The model to pass to the view
+*/
 Template.prototype.createPartialHelper = function(layout, model) {
   return function(partialPath) {
     var args = [].slice.call(arguments, 1);
     var template = getTemplate(
-      path.join(
-        this.options.dirname || this.options.express.settings.views,
-        partialPath
-      ),
+      path.join(this.options.dirname || this.options.express.settings.views, partialPath),
       this.options.express
     );
 
     if (args.length) {
-      model = _.assign.apply(_, [{}, model].concat(args));
+      model = _.assign.apply(_, [
+        {},
+        model
+      ].concat(args));
     }
 
-    return template.render({ layout: layout, model: model, isPartial: true });
+    return template.render({ layout: layout, model: model, isPartial: true, });
   }.bind(this);
 };
 
 /**
- * Renders the template.
- * If callback is passed, it will be called asynchronously.
- * @param {Object} options Options to pass to the view
- * @param {Object} [options.layout] The layout key/value
- * @param {Object} options.model The model to pass to the view
- * @param {Function} [callback] (Optional) The async node style callback
- */
+* Renders the template.
+* If callback is passed, it will be called asynchronously.
+* @param {Object} options Options to pass to the view
+* @param {Object} [options.layout] The layout key/value
+* @param {Object} options.model The model to pass to the view
+* @param {Function} [callback] (Optional) The async node style callback
+*/
 Template.prototype.render = function(options, callback) {
-  var isAsync = callback && typeof callback === "function";
+  var isAsync = callback && typeof callback === 'function';
   var layout = options.layout;
   var model = options.model;
   var layoutModel = _.merge({}, this.options.config, layout);
@@ -187,6 +187,7 @@ Template.prototype.render = function(options, callback) {
   for (var key in this.templates) {
     if (this.templates.hasOwnProperty(key)) {
       try {
+
         var viewModel = _.union(
           [
             layoutModel,
@@ -196,25 +197,23 @@ Template.prototype.render = function(options, callback) {
           ],
           this.viewData,
           _.chain(this.shortcuts)
-            .keys()
-            .map(function(shortcut) {
-              return options.model._locals[this.shortcuts[shortcut]] || null;
-            }, this)
-            .valueOf()
+          .keys()
+          .map(function(shortcut) {
+            return options.model._locals[this.shortcuts[shortcut]] || null;
+          }, this)
+          .valueOf()
         );
 
         layoutModel[key] = this.templates[key].apply(
           this.templates[key],
           viewModel
         );
-      } catch (err) {
+      }
+      catch (err) {
         var error = new Error(
-          "Failed to render with doT" +
-            " (" +
-            this.options.filename +
-            ")" +
-            " - " +
-            err.toString()
+          'Failed to render with doT' +
+          ' (' + this.options.filename + ')' +
+          ' - ' + err.toString()
         );
 
         if (isAsync) {
@@ -228,8 +227,9 @@ Template.prototype.render = function(options, callback) {
 
   // no layout
   if (!this.isLayout) {
+
     // append the header to the master page
-    var result = (!options.isPartial ? settings.header : "") + layoutModel.body;
+    var result = (!options.isPartial ? settings.header : '') + layoutModel.body;
 
     if (isAsync) {
       callback(null, result);
@@ -240,7 +240,7 @@ Template.prototype.render = function(options, callback) {
   // render the master sync
   if (!isAsync) {
     var masterTemplate = getTemplate(this.master, this.options.express);
-    return masterTemplate.render({ layout: layoutModel, model: model });
+    return masterTemplate.render({ layout: layoutModel, model: model, });
   }
 
   // render the master async
@@ -250,22 +250,20 @@ Template.prototype.render = function(options, callback) {
       return;
     }
 
-    return masterTemplate.render(
-      { layout: layoutModel, model: model },
-      callback
-    );
+    return masterTemplate.render({ layout: layoutModel, model: model, }, callback);
   });
 };
 
 /**
- * Retrieves a template given a filename.
- * Uses cache for optimization (if options.cache is true).
- * If callback is passed, it will be called asynchronously.
- * @param {String} filename The path to the template
- * @param {Object} options The option sent by express
- * @param {Function} [callback] (Optional) The async node style callback
- */
+* Retrieves a template given a filename.
+* Uses cache for optimization (if options.cache is true).
+* If callback is passed, it will be called asynchronously.
+* @param {String} filename The path to the template
+* @param {Object} options The option sent by express
+* @param {Function} [callback] (Optional) The async node style callback
+*/
 function getTemplate(filename, options, callback) {
+
   // cache
   if (options && options.cache) {
     var fromCache = cache.get(filename);
@@ -276,10 +274,11 @@ function getTemplate(filename, options, callback) {
     //console.log('cache miss');
   }
 
-  var isAsync = callback && typeof callback === "function";
+  var isAsync = callback && typeof callback === 'function';
 
   // function to call when retieved template
   function done(err, template) {
+
     // cache
     if (options && options.cache && template) {
       cache.set(filename, template);
@@ -301,6 +300,7 @@ function getTemplate(filename, options, callback) {
   buildTemplate(filename, options, done);
 }
 
+
 /**
  * Builds a template
  * If callback is passed, it will be called asynchronously.
@@ -309,18 +309,15 @@ function getTemplate(filename, options, callback) {
  * @param {Function} callback (Optional) The async node style callback
  */
 function buildTemplate(filename, options, callback) {
-  var isAsync = callback && typeof callback === "function",
-    getTemplateContentFn =
-      options.getTemplate && typeof options.getTemplate === "function"
-        ? options.getTemplate
-        : getTemplateContentFromFile;
+  var isAsync = callback && typeof callback === 'function',
+      getTemplateContentFn = options.getTemplate  && typeof options.getTemplate === 'function' ? options.getTemplate : getTemplateContentFromFile;
 
   // sync
   if (!isAsync) {
     return builtTemplateFromString(
-      getTemplateContentFn(filename, options),
-      filename,
-      options
+        getTemplateContentFn(filename, options),
+        filename,
+        options
     );
   }
 
@@ -340,100 +337,100 @@ function buildTemplate(filename, options, callback) {
  * @param {Function} callback (Optional) The async node style callback
  */
 function getTemplateContentFromFile(filename, options, callback) {
-  var isAsync = callback && typeof callback === "function";
+  var isAsync = callback && typeof callback === 'function';
 
   // sync
   if (!isAsync) {
-    return fs.readFileSync(filename, "utf8");
+    return fs.readFileSync(filename, 'utf8');
   }
 
   // async
-  fs.readFile(filename, "utf8", function(err, str) {
+  fs.readFile(filename, 'utf8', function(err, str) {
     if (err) {
-      callback(new Error("Failed to open view file (" + filename + ")"));
+      callback(new Error('Failed to open view file (' + filename + ')'));
       return;
     }
 
     try {
       callback(null, str);
-    } catch (err) {
+    }
+    catch (err) {
       callback(err);
     }
   });
 }
 
 /**
- * Builds a template from a string
- * @param {String} str The template string
- * @param {String} filename The path to the template
- * @param {Object} options The options sent by express
- * @return {Template} The template object
- */
+* Builds a template from a string
+* @param {String} str The template string
+* @param {String} filename The path to the template
+* @param {Object} options The options sent by express
+* @return {Template} The template object
+*/
 function builtTemplateFromString(str, filename, options) {
-  // try {
-  if (!str) return "";
-  var config = {};
 
-  // config at the beginning of the file
-  str.replace(settings.config, function(m, conf) {
-    config = yaml.safeLoad(conf);
-  });
+  try {
+    var config = {};
 
-  // strip comments
-  if (settings.stripComment) {
-    str = str.replace(settings.comment, function(m, code, assign, value) {
-      return "";
+    // config at the beginning of the file
+    str.replace(settings.config, function(m, conf) {
+      config = yaml.safeLoad(conf);
+    });
+
+    // strip comments
+    if (settings.stripComment) {
+      str = str.replace(settings.comment, function(m, code, assign, value) {
+        return '';
+      });
+    }
+
+    // strip whitespace
+    if (settings.stripWhitespace) {
+      settings.dot.strip = settings.stripWhitespace;
+    }
+
+    // layout sections
+    var sections = {};
+
+    if (!config.layout) {
+      sections.body = str;
+    }
+    else {
+      str.replace(settings.dot.define, function(m, code, assign, value) {
+        sections[code] = value;
+      });
+    }
+
+    var templateSettings = _.pick(options, ['settings']);
+    options.getTemplate && (templateSettings.getTemplate = options.getTemplate);
+    return new Template({
+      express: templateSettings,
+      config: config,
+      sections: sections,
+      dirname: path.dirname(filename),
+      filename: filename
     });
   }
-
-  // strip whitespace
-  if (settings.stripWhitespace) {
-    settings.dot.strip = settings.stripWhitespace;
+  catch (err) {
+    throw new Error(
+      'Failed to build template' +
+      ' (' + filename + ')' +
+      ' - ' + err.toString()
+    );
   }
-
-  // layout sections
-  var sections = {};
-
-  if (!config.layout) {
-    sections.body = str;
-  } else {
-    str.replace(settings.dot.define, function(m, code, assign, value) {
-      sections[code] = value;
-    });
-  }
-
-  var templateSettings = _.pick(options, ["settings"]);
-  options.getTemplate && (templateSettings.getTemplate = options.getTemplate);
-  return new Template({
-    express: templateSettings,
-    config: config,
-    sections: sections,
-    dirname: path.dirname(filename),
-    filename: filename
-  });
-  // } catch (err) {
-  //   throw new Error(
-  //     "Failed to build template" +
-  //       " (" +
-  //       filename +
-  //       ")" +
-  //       " - " +
-  //       err.toString()
-  //   );
-  // }
 }
 
 /**
- * Render a template
- * @param {String} filename The path to the file
- * @param {Object} options The model to pass to the view
- * @param {Function} callback (Optional) The async node style callback
- */
+* Render a template
+* @param {String} filename The path to the file
+* @param {Object} options The model to pass to the view
+* @param {Function} callback (Optional) The async node style callback
+*/
 function render(filename, options, callback) {
-  var isAsync = callback && typeof callback === "function";
+  var isAsync = callback && typeof callback === 'function';
 
   if (!isAsync) {
-    return renderSync(filename, options);
+    return renderSync(filename, options)
   }
 
   getTemplate(filename, options, function(err, template) {
@@ -441,29 +438,29 @@ function render(filename, options, callback) {
       return callback(err);
     }
 
-    template.render({ model: options }, callback);
+    template.render({ model: options, }, callback);
   });
 }
 
 /**
- * Renders a template sync
- * @param {String} filename The path to the file
- * @param {Object} options The model to pass to the view
- */
+* Renders a template sync
+* @param {String} filename The path to the file
+* @param {Object} options The model to pass to the view
+*/
 function renderSync(filename, options) {
   var template = getTemplate(filename, options);
-  return template.render({ model: options });
+  return template.render({ model: options, });
 }
 
 /**
- * Render directly from a string
- * @param {String} templateString The template string
- * @param {Object} options The model to pass to the view
- * @param {Function} callback (Optional) The async node style callback
- */
+* Render directly from a string
+* @param {String} templateString The template string
+* @param {Object} options The model to pass to the view
+* @param {Function} callback (Optional) The async node style callback
+*/
 function renderString(templateString, options, callback) {
-  var template = builtTemplateFromString(templateString, "", options);
-  return template.render({ model: options }, callback);
+  var template = builtTemplateFromString(templateString, '', options);
+  return template.render({ model: options, }, callback);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,38 +1,41 @@
-var _ = require('lodash');
-var fs = require('fs');
-var dot = require('dot');
-var path = require('path');
-var yaml = require('js-yaml');
+var _ = require("lodash");
+var fs = require("fs");
+var dot = require("dot");
+var path = require("path");
+var yaml = require("js-yaml");
 
 /**
-* Engine settings
-*/
+ * Engine settings
+ */
 var settings = {
   config: /^---([\s\S]+?)---/g,
   comment: /<!--([\s\S]+?)-->/g,
-  header: '',
+  header: "",
 
   stripComment: false,
   stripWhitespace: false, // shortcut to dot.strip
 
   dot: {
-    evaluate: /\[\[([\s\S]+?)]]/g,
-    interpolate: /\[\[=([\s\S]+?)]]/g,
-    encode: /\[\[!([\s\S]+?)]]/g,
-    use: /\[\[#([\s\S]+?)]]/g,
-    define: /\[\[##\s*([\w\.$]+)\s*(:|=)([\s\S]+?)#]]/g,
-    conditional: /\[\[\?(\?)?\s*([\s\S]*?)\s*]]/g,
-    iterate: /\[\[~\s*(?:]]|([\s\S]+?)\s*:\s*([\w$]+)\s*(?::\s*([\w$]+))?\s*]])/g,
-    varname: 'layout, partial, locals, model',
+    evaluate: /\[\[([\s\S]+?)\]\]/g,
+    interpolate: /\[\[=([\s\S]+?)\]\]/g,
+    encode: /\[\[!([\s\S]+?)\]\]/g,
+    use: /\[\[#([\s\S]+?)\]\]/g,
+    useParams: /(^|[^\w$])def(?:\.|\[[\'\"])([\w$\.]+)(?:[\'\"]\])?\s*\:\s*([\w$\.]+|\"[^\"]+\"|\'[^\']+\'|\[[^\]]+\])/g,
+    define: /\[\[##\s*([\w\.$]+)\s*(:|=)([\s\S]+?)#\]\]/g,
+    defineParams: /^\s*([\w$]+):([\s\S]+)/,
+    conditional: /\[\[\?(\?)?\s*([\s\S]*?)\s*\]\]/g,
+    iterate: /\[\[~\s*(?:\]\]|([\s\S]+?)\s*:\s*([\w$]+)\s*(?::\s*([\w$]+))?\s*\]\])/g,
+    varname: "layout, partial, locals, model",
     strip: false,
     append: true,
-    selfcontained: false
+    selfcontained: false,
+    doNotSkipEncoded: false
   }
 };
 
 /**
-* Cache store
-*/
+ * Cache store
+ */
 var cache = {
   cache: {},
 
@@ -48,8 +51,8 @@ var cache = {
 };
 
 /**
-* Server-side helper
-*/
+ * Server-side helper
+ */
 function DotDef(options) {
   this.options = options;
   this.dirname = options.dirname;
@@ -57,12 +60,11 @@ function DotDef(options) {
 }
 
 DotDef.prototype = {
-
   partial: function(partialPath) {
-
-    console.log('DEPRECATED: ' +
-    'Please use the new syntax for partials' +
-    ' [[= partial(\'path/to/partial\') ]]'
+    console.log(
+      "DEPRECATED: " +
+        "Please use the new syntax for partials" +
+        " [[= partial('path/to/partial') ]]"
     );
 
     var template = getTemplate(
@@ -70,35 +72,34 @@ DotDef.prototype = {
       this.model
     );
 
-    return template.render({ model: this.model, isPartial: true, } );
+    return template.render({ model: this.model, isPartial: true });
   }
-
 };
 
 /**
-* @constructor Template object with a layout structure. This object is cached
-* if the 'options.cache' set by express is true.
-* @param {Object} options The constructor parameters:
-*
-* {Object} engine The option from the engine
-*
-* There are 2 options
-*
-* Case 1: A layout view
-* {String} master The master template filename
-* {Object} sections A key/value containing the sections of the template
-*
-* Case 2: A standalone view
-* {String} body The template string
-*/
+ * @constructor Template object with a layout structure. This object is cached
+ * if the 'options.cache' set by express is true.
+ * @param {Object} options The constructor parameters:
+ *
+ * {Object} engine The option from the engine
+ *
+ * There are 2 options
+ *
+ * Case 1: A layout view
+ * {String} master The master template filename
+ * {Object} sections A key/value containing the sections of the template
+ *
+ * Case 2: A standalone view
+ * {String} body The template string
+ */
 function Template(options) {
   this.options = options;
 
   // layout
   this.isLayout = !!options.config.layout;
-  this.master = this.isLayout ?
-    path.join(options.dirname, options.config.layout) :
-    null;
+  this.master = this.isLayout
+    ? path.join(options.dirname, options.config.layout)
+    : null;
 
   // build the doT templates
   this.templates = {};
@@ -107,14 +108,15 @@ function Template(options) {
 
   // view data
   this.viewData = [];
-  if (_.has(options.express, 'settings')
-    && _.has(options.express.settings, 'view data')
+  if (
+    _.has(options.express, "settings") &&
+    _.has(options.express.settings, "view data")
   ) {
     this.settings.varname = _.reduce(
-      options.express.settings['view data'],
+      options.express.settings["view data"],
       function(result, value, key) {
         this.viewData.push(value);
-        return result + ', ' + key;
+        return result + ", " + key;
       },
       settings.dot.varname,
       this
@@ -123,11 +125,12 @@ function Template(options) {
 
   // view shortcut
   this.shortcuts = [];
-  if (_.has(options.express, 'settings')
-    && _.has(options.express.settings, 'view shortcut')
+  if (
+    _.has(options.express, "settings") &&
+    _.has(options.express.settings, "view shortcut")
   ) {
-    this.shortcuts = options.express.settings['view shortcut'];
-    this.settings.varname += ', ' + _.keys(this.shortcuts).join();
+    this.shortcuts = options.express.settings["view shortcut"];
+    this.settings.varname += ", " + _.keys(this.shortcuts).join();
   }
 
   // doT template
@@ -143,39 +146,39 @@ function Template(options) {
 }
 
 /**
-* Partial method helper
-* @param {Object} layout The layout to pass to the view
-* @param {Object} model The model to pass to the view
-*/
+ * Partial method helper
+ * @param {Object} layout The layout to pass to the view
+ * @param {Object} model The model to pass to the view
+ */
 Template.prototype.createPartialHelper = function(layout, model) {
   return function(partialPath) {
     var args = [].slice.call(arguments, 1);
     var template = getTemplate(
-      path.join(this.options.dirname || this.options.express.settings.views, partialPath),
+      path.join(
+        this.options.dirname || this.options.express.settings.views,
+        partialPath
+      ),
       this.options.express
     );
 
     if (args.length) {
-      model = _.assign.apply(_, [
-        {},
-        model
-      ].concat(args));
+      model = _.assign.apply(_, [{}, model].concat(args));
     }
 
-    return template.render({ layout: layout, model: model, isPartial: true, });
+    return template.render({ layout: layout, model: model, isPartial: true });
   }.bind(this);
 };
 
 /**
-* Renders the template.
-* If callback is passed, it will be called asynchronously.
-* @param {Object} options Options to pass to the view
-* @param {Object} [options.layout] The layout key/value
-* @param {Object} options.model The model to pass to the view
-* @param {Function} [callback] (Optional) The async node style callback
-*/
+ * Renders the template.
+ * If callback is passed, it will be called asynchronously.
+ * @param {Object} options Options to pass to the view
+ * @param {Object} [options.layout] The layout key/value
+ * @param {Object} options.model The model to pass to the view
+ * @param {Function} [callback] (Optional) The async node style callback
+ */
 Template.prototype.render = function(options, callback) {
-  var isAsync = callback && typeof callback === 'function';
+  var isAsync = callback && typeof callback === "function";
   var layout = options.layout;
   var model = options.model;
   var layoutModel = _.merge({}, this.options.config, layout);
@@ -184,7 +187,6 @@ Template.prototype.render = function(options, callback) {
   for (var key in this.templates) {
     if (this.templates.hasOwnProperty(key)) {
       try {
-
         var viewModel = _.union(
           [
             layoutModel,
@@ -194,23 +196,25 @@ Template.prototype.render = function(options, callback) {
           ],
           this.viewData,
           _.chain(this.shortcuts)
-          .keys()
-          .map(function(shortcut) {
-            return options.model._locals[this.shortcuts[shortcut]] || null;
-          }, this)
-          .valueOf()
+            .keys()
+            .map(function(shortcut) {
+              return options.model._locals[this.shortcuts[shortcut]] || null;
+            }, this)
+            .valueOf()
         );
 
         layoutModel[key] = this.templates[key].apply(
           this.templates[key],
           viewModel
         );
-      }
-      catch (err) {
+      } catch (err) {
         var error = new Error(
-          'Failed to render with doT' +
-          ' (' + this.options.filename + ')' +
-          ' - ' + err.toString()
+          "Failed to render with doT" +
+            " (" +
+            this.options.filename +
+            ")" +
+            " - " +
+            err.toString()
         );
 
         if (isAsync) {
@@ -224,9 +228,8 @@ Template.prototype.render = function(options, callback) {
 
   // no layout
   if (!this.isLayout) {
-
     // append the header to the master page
-    var result = (!options.isPartial ? settings.header : '') + layoutModel.body;
+    var result = (!options.isPartial ? settings.header : "") + layoutModel.body;
 
     if (isAsync) {
       callback(null, result);
@@ -237,7 +240,7 @@ Template.prototype.render = function(options, callback) {
   // render the master sync
   if (!isAsync) {
     var masterTemplate = getTemplate(this.master, this.options.express);
-    return masterTemplate.render({ layout: layoutModel, model: model, });
+    return masterTemplate.render({ layout: layoutModel, model: model });
   }
 
   // render the master async
@@ -247,20 +250,22 @@ Template.prototype.render = function(options, callback) {
       return;
     }
 
-    return masterTemplate.render({ layout: layoutModel, model: model, }, callback);
+    return masterTemplate.render(
+      { layout: layoutModel, model: model },
+      callback
+    );
   });
 };
 
 /**
-* Retrieves a template given a filename.
-* Uses cache for optimization (if options.cache is true).
-* If callback is passed, it will be called asynchronously.
-* @param {String} filename The path to the template
-* @param {Object} options The option sent by express
-* @param {Function} [callback] (Optional) The async node style callback
-*/
+ * Retrieves a template given a filename.
+ * Uses cache for optimization (if options.cache is true).
+ * If callback is passed, it will be called asynchronously.
+ * @param {String} filename The path to the template
+ * @param {Object} options The option sent by express
+ * @param {Function} [callback] (Optional) The async node style callback
+ */
 function getTemplate(filename, options, callback) {
-
   // cache
   if (options && options.cache) {
     var fromCache = cache.get(filename);
@@ -271,11 +276,10 @@ function getTemplate(filename, options, callback) {
     //console.log('cache miss');
   }
 
-  var isAsync = callback && typeof callback === 'function';
+  var isAsync = callback && typeof callback === "function";
 
   // function to call when retieved template
   function done(err, template) {
-
     // cache
     if (options && options.cache && template) {
       cache.set(filename, template);
@@ -297,7 +301,6 @@ function getTemplate(filename, options, callback) {
   buildTemplate(filename, options, done);
 }
 
-
 /**
  * Builds a template
  * If callback is passed, it will be called asynchronously.
@@ -306,15 +309,18 @@ function getTemplate(filename, options, callback) {
  * @param {Function} callback (Optional) The async node style callback
  */
 function buildTemplate(filename, options, callback) {
-  var isAsync = callback && typeof callback === 'function',
-      getTemplateContentFn = options.getTemplate  && typeof options.getTemplate === 'function' ? options.getTemplate : getTemplateContentFromFile;
+  var isAsync = callback && typeof callback === "function",
+    getTemplateContentFn =
+      options.getTemplate && typeof options.getTemplate === "function"
+        ? options.getTemplate
+        : getTemplateContentFromFile;
 
   // sync
   if (!isAsync) {
     return builtTemplateFromString(
-        getTemplateContentFn(filename, options),
-        filename,
-        options
+      getTemplateContentFn(filename, options),
+      filename,
+      options
     );
   }
 
@@ -334,100 +340,100 @@ function buildTemplate(filename, options, callback) {
  * @param {Function} callback (Optional) The async node style callback
  */
 function getTemplateContentFromFile(filename, options, callback) {
-  var isAsync = callback && typeof callback === 'function';
+  var isAsync = callback && typeof callback === "function";
 
   // sync
   if (!isAsync) {
-    return fs.readFileSync(filename, 'utf8');
+    return fs.readFileSync(filename, "utf8");
   }
 
   // async
-  fs.readFile(filename, 'utf8', function(err, str) {
+  fs.readFile(filename, "utf8", function(err, str) {
     if (err) {
-      callback(new Error('Failed to open view file (' + filename + ')'));
+      callback(new Error("Failed to open view file (" + filename + ")"));
       return;
     }
 
     try {
       callback(null, str);
-    }
-    catch (err) {
+    } catch (err) {
       callback(err);
     }
   });
 }
 
 /**
-* Builds a template from a string
-* @param {String} str The template string
-* @param {String} filename The path to the template
-* @param {Object} options The options sent by express
-* @return {Template} The template object
-*/
+ * Builds a template from a string
+ * @param {String} str The template string
+ * @param {String} filename The path to the template
+ * @param {Object} options The options sent by express
+ * @return {Template} The template object
+ */
 function builtTemplateFromString(str, filename, options) {
+  // try {
+  if (!str) return "";
+  var config = {};
 
-  try {
-    var config = {};
+  // config at the beginning of the file
+  str.replace(settings.config, function(m, conf) {
+    config = yaml.safeLoad(conf);
+  });
 
-    // config at the beginning of the file
-    str.replace(settings.config, function(m, conf) {
-      config = yaml.safeLoad(conf);
-    });
-
-    // strip comments
-    if (settings.stripComment) {
-      str = str.replace(settings.comment, function(m, code, assign, value) {
-        return '';
-      });
-    }
-
-    // strip whitespace
-    if (settings.stripWhitespace) {
-      settings.dot.strip = settings.stripWhitespace;
-    }
-
-    // layout sections
-    var sections = {};
-
-    if (!config.layout) {
-      sections.body = str;
-    }
-    else {
-      str.replace(settings.dot.define, function(m, code, assign, value) {
-        sections[code] = value;
-      });
-    }
-
-    var templateSettings = _.pick(options, ['settings']);
-    options.getTemplate && (templateSettings.getTemplate = options.getTemplate);
-    return new Template({
-      express: templateSettings,
-      config: config,
-      sections: sections,
-      dirname: path.dirname(filename),
-      filename: filename
+  // strip comments
+  if (settings.stripComment) {
+    str = str.replace(settings.comment, function(m, code, assign, value) {
+      return "";
     });
   }
-  catch (err) {
-    throw new Error(
-      'Failed to build template' +
-      ' (' + filename + ')' +
-      ' - ' + err.toString()
-    );
+
+  // strip whitespace
+  if (settings.stripWhitespace) {
+    settings.dot.strip = settings.stripWhitespace;
   }
+
+  // layout sections
+  var sections = {};
+
+  if (!config.layout) {
+    sections.body = str;
+  } else {
+    str.replace(settings.dot.define, function(m, code, assign, value) {
+      sections[code] = value;
+    });
+  }
+
+  var templateSettings = _.pick(options, ["settings"]);
+  options.getTemplate && (templateSettings.getTemplate = options.getTemplate);
+  return new Template({
+    express: templateSettings,
+    config: config,
+    sections: sections,
+    dirname: path.dirname(filename),
+    filename: filename
+  });
+  // } catch (err) {
+  //   throw new Error(
+  //     "Failed to build template" +
+  //       " (" +
+  //       filename +
+  //       ")" +
+  //       " - " +
+  //       err.toString()
+  //   );
+  // }
 }
 
 /**
-* Render a template
-* @param {String} filename The path to the file
-* @param {Object} options The model to pass to the view
-* @param {Function} callback (Optional) The async node style callback
-*/
+ * Render a template
+ * @param {String} filename The path to the file
+ * @param {Object} options The model to pass to the view
+ * @param {Function} callback (Optional) The async node style callback
+ */
 function render(filename, options, callback) {
-  var isAsync = callback && typeof callback === 'function';
+  var isAsync = callback && typeof callback === "function";
 
   if (!isAsync) {
-    return renderSync(filename, options)
+    return renderSync(filename, options);
   }
 
   getTemplate(filename, options, function(err, template) {
@@ -435,29 +441,29 @@ function render(filename, options, callback) {
       return callback(err);
     }
 
-    template.render({ model: options, }, callback);
+    template.render({ model: options }, callback);
   });
 }
 
 /**
-* Renders a template sync
-* @param {String} filename The path to the file
-* @param {Object} options The model to pass to the view
-*/
+ * Renders a template sync
+ * @param {String} filename The path to the file
+ * @param {Object} options The model to pass to the view
+ */
 function renderSync(filename, options) {
   var template = getTemplate(filename, options);
-  return template.render({ model: options, });
+  return template.render({ model: options });
 }
 
 /**
-* Render directly from a string
-* @param {String} templateString The template string
-* @param {Object} options The model to pass to the view
-* @param {Function} callback (Optional) The async node style callback
-*/
+ * Render directly from a string
+ * @param {String} templateString The template string
+ * @param {Object} options The model to pass to the view
+ * @param {Function} callback (Optional) The async node style callback
+ */
 function renderString(templateString, options, callback) {
-  var template = builtTemplateFromString(templateString, '', options);
-  return template.render({ model: options, }, callback);
+  var template = builtTemplateFromString(templateString, "", options);
+  return template.render({ model: options }, callback);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   },
   "engineStrict": true,
   "dependencies": {
-    "dot": "^1.0.3",
+    "dot": "^1.1.2",
     "js-yaml": "^3.2.7",
-    "lodash": "^3.5.0"
+    "lodash": "^4.17.11"
   },
   "optionalDependencies": {},
   "devDependencies": {
-    "mocha": "^2.2.1",
-    "mock-fs": "^2.5.0",
-    "should": "^5.2.0"
+    "mocha": "^6.1.4",
+    "mock-fs": "^4.10.1",
+    "should": "^13.2.3"
   }
 }


### PR DESCRIPTION
I wasn't able to use template inline `def` with params. like:

```
{{##def.snippet:message:
    <div>{{=message}}</div>
#}}

{{#def.snippet:'hello world!'}}
```

So I added `doT` other configs (`useParams` and `defineParams` regex) to use this syntax.